### PR TITLE
Add ownProperty check to iterator

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,7 @@ function generateUtterances(str, slots, dictionary, exhaustiveUtterances) {
 
   // Convert all {-|Name} to {Name} to accomodate slot literals
   for (var idx in utterances) {
+    if (!utterances.hasOwnProperty(idx)) continue;
     utterances[idx] = utterances[idx].replace(/\{\-\|/g, "{");
   }
 


### PR DESCRIPTION
One of the indices returned when iterating utterances was the string
'iterator'. Add a check for hasOwnProperty to avoid an error being
thrown.

Using node 6.9.1, calling code was written in Typescript 2.1.4.

My stack trace was:

    TypeError: utterances[idx].replace is not a function
      at generateUtterances (/home/josh/src/veronica/node_modules/alexa-utterances/index.js:162:39)
      at /home/josh/src/veronica/node_modules/alexa-app/index.js:460:22
      at Array.forEach (native)
      at utterances (/home/josh/src/veronica/node_modules/alexa-app/index.js:459:34)
      <snip>